### PR TITLE
Fix crash

### DIFF
--- a/srv6/template-script.sh
+++ b/srv6/template-script.sh
@@ -45,10 +45,10 @@ for ENDPOINT in ${ENDPOINTS}; do
 done
 
 if [ -n "$LINUX_HEADEND_SET_SOURCE_ADDRESS" ]; then
-	LINUX_HEADEND_SET_SOURCE_ADDRESS_SUB="linux-headend-set-source-address: ${LINUX_HEADEND_SET_SOURCE_ADDRESS}"
+	LINUX_HEADEND_SET_SOURCE_ADDRESS_SUB="linux-headend-set-source-address: \"${LINUX_HEADEND_SET_SOURCE_ADDRESS}\""
 fi
 if [ -n "$IPV4_HEADEND_PREFIX" ]; then
-	IPV4_HEADEND_PREFIX_SUB="ipv4-headend-prefix: ${IPV4_HEADEND_PREFIX}"
+	IPV4_HEADEND_PREFIX_SUB="ipv4-headend-prefix: \"${IPV4_HEADEND_PREFIX}\""
 fi
 
 awk \


### PR DESCRIPTION
- nextmm/srv6: `Error loading config, exiting…: yaml: line 6: mapping values are not allowed in this context`
- docker: `Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: can't get final child's PID from pipe: EOF: unknown`